### PR TITLE
Update build.zig.zon, POSIX code for Zig 0.14

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,8 @@
 .{
-    .name = "termsize",
+    .name = .termsize,
+    .fingerprint = 0x657ac701d6016cd2,
     .version = "0.1.0",
-    .minimum_zig_version = "0.12.0",
+    .minimum_zig_version = "0.14.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/main.zig
+++ b/src/main.zig
@@ -45,7 +45,7 @@ pub fn termSize(file: std.fs.File) !?TermSize {
             };
         },
         .linux, .macos => blk: {
-            var buf: std.posix.system.winsize = undefined;
+            var buf: std.posix.winsize = undefined;
             break :blk switch (std.posix.errno(
                 std.posix.system.ioctl(
                     file.handle,
@@ -54,8 +54,8 @@ pub fn termSize(file: std.fs.File) !?TermSize {
                 ),
             )) {
                 .SUCCESS => TermSize{
-                    .width = buf.ws_col,
-                    .height = buf.ws_row,
+                    .width = buf.col,
+                    .height = buf.row,
                 },
                 else => error.IoctlError,
             };


### PR DESCRIPTION
Similar to #3, but also fixes how the `winsize` type is retrieved (previous line caused build errors)
Also updates the `build.zig.zon` file with Zig 0.14 information (fingerprint, change package name to enum literal)
Bumped Zig version since it no longer builds on 0.13